### PR TITLE
Use store instead of props to pass userUUID

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -57,7 +57,7 @@ export default function DashboardPage() {
       </div>
       <div className="hidden items-start justify-center gap-6 rounded-lg p-8 md:grid lg:grid-cols-2 xl:grid-cols-3">
         <DashboardContainer>
-          <SelectCoachingSession userUUID={userUUID} />
+          <SelectCoachingSession />
         </DashboardContainer>
       </div>
     </>

--- a/src/components/ui/dashboard/select-coaching-session.tsx
+++ b/src/components/ui/dashboard/select-coaching-session.tsx
@@ -22,15 +22,7 @@ import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { Organization, defaultOrganizations } from "@/types/organization";
 import { useEffect, useState } from "react";
 
-export interface CoachingSessionProps {
-  /** The current logged in user's UUID */
-  userUUID: string;
-}
-
-export function SelectCoachingSession({
-  userUUID,
-  ...props
-}: CoachingSessionProps) {
+export function SelectCoachingSession() {
   const [organizationSelection, setOrganizationSelection] =
     useState<string>("");
   const [relationshipSelection, setRelationshipSelection] =

--- a/src/components/ui/dashboard/select-coaching-session.tsx
+++ b/src/components/ui/dashboard/select-coaching-session.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { fetchOrganizationsByUserId } from "@/lib/api/organizations";
+import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { Organization, defaultOrganizations } from "@/types/organization";
 import { useEffect, useState } from "react";
 
@@ -28,18 +29,15 @@ export interface CoachingSessionProps {
   userUUID: string;
 }
 
-export function SelectCoachingSession({
-  userUUID,
-  ...props
-}: CoachingSessionProps) {
+export function SelectCoachingSession() {
   const [organizations, setOrganizations] = useState<Organization[]>(
     defaultOrganizations()
   );
-  useEffect(() => {
-    async function loadOrganizations() {
-      if (!userUUID) return;
+  const { userUUID } = useAuthStore((state) => state);
 
-      await fetchOrganizationsByUserId(userUUID)
+  useEffect(() => {
+    if (userUUID) {
+      fetchOrganizationsByUserId(userUUID)
         .then(([orgs]) => {
           setOrganizations(orgs);
         })
@@ -47,7 +45,6 @@ export function SelectCoachingSession({
           console.error("Failed to fetch Organizations: " + err);
         });
     }
-    loadOrganizations();
   }, [userUUID]);
 
   return (


### PR DESCRIPTION
## Description
Cleans up the `SelectCoachingSession` component to use the Zustand store for grabbing userUUID instead of props.
 
#### GitHub Issue: [Resolves] #17 

### Changes
* ...
* ...
* ...

### Screenshots / Videos Showing UI Changes (if applicable)


### Testing Strategy
_describe how you or someone else can test and verify the changes_


### Concerns
_describe any concerns that might be worth mentioning or discussing_