### PR TITLE
Tweak wording and UX of joining a session on the dashboard

### DIFF
--- a/src/components/ui/dashboard/select-coaching-session.tsx
+++ b/src/components/ui/dashboard/select-coaching-session.tsx
@@ -9,7 +9,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -18,7 +17,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { fetchOrganizationsByUserId } from "@/lib/api/organizations";
 import { Organization, defaultOrganizations } from "@/types/organization";
 import { useEffect, useState } from "react";
@@ -32,6 +30,31 @@ export function SelectCoachingSession({
   userUUID,
   ...props
 }: CoachingSessionProps) {
+  const [organizationSelection, setOrganizationSelection] =
+    useState<string>("");
+  const [relationshipSelection, setRelationshipSelection] =
+    useState<string>("");
+  const [coachSessionSelection, setCoachingSessionSelection] =
+    useState<string>("");
+
+  const handleOrganizationSelectionChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    setOrganizationSelection(event.target.value);
+  };
+
+  const handleRelationshipSelectionChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    setRelationshipSelection(event.target.value);
+  };
+
+  const handleCoachingSessionChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ) => {
+    setCoachingSessionSelection(event.target.value);
+  };
+
   const [organizations, setOrganizations] = useState<Organization[]>(
     defaultOrganizations()
   );
@@ -53,13 +76,19 @@ export function SelectCoachingSession({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Organization Relationship</CardTitle>
-        <CardDescription>Select current organization & coachee</CardDescription>
+        <CardTitle>Join a Coaching Session</CardTitle>
+        <CardDescription>
+          Select current organization, relationship and session
+        </CardDescription>
       </CardHeader>
       <CardContent className="grid gap-6">
         <div className="grid gap-2">
           <Label htmlFor="organization">Organization</Label>
-          <Select defaultValue="0">
+          <Select
+            defaultValue="0"
+            value={organizationSelection}
+            onValueChange={setOrganizationSelection}
+          >
             <SelectTrigger id="organization">
               <SelectValue placeholder="Select" />
             </SelectTrigger>
@@ -74,7 +103,12 @@ export function SelectCoachingSession({
         </div>
         <div className="grid gap-2">
           <Label htmlFor="relationship">Relationship</Label>
-          <Select defaultValue="caleb">
+          <Select
+            defaultValue="caleb"
+            disabled={!organizationSelection}
+            value={relationshipSelection}
+            onValueChange={setRelationshipSelection}
+          >
             <SelectTrigger id="relationship">
               <SelectValue placeholder="Select" />
             </SelectTrigger>
@@ -90,7 +124,12 @@ export function SelectCoachingSession({
         </div>
         <div className="grid gap-2">
           <Label htmlFor="session">Coaching Session</Label>
-          <Select defaultValue="today">
+          <Select
+            defaultValue="today"
+            disabled={!relationshipSelection}
+            value={coachSessionSelection}
+            onValueChange={setCoachingSessionSelection}
+          >
             <SelectTrigger id="session">
               <SelectValue placeholder="Select" />
             </SelectTrigger>
@@ -102,8 +141,12 @@ export function SelectCoachingSession({
         </div>
       </CardContent>
       <CardFooter>
-        <Button variant="outline" className="w-full">
-          Apply
+        <Button
+          variant="outline"
+          className="w-full"
+          disabled={!coachSessionSelection}
+        >
+          Join
         </Button>
       </CardFooter>
     </Card>


### PR DESCRIPTION
## Description
Update the wording on the dashboard to be about selecting a coaching session, and disable the select boxes until each is selected in proper order, including the join session button.


#### GitHub Issue: N/A

### Changes
* Update the title of the card on the dashboard to focus on joining a session instead of selecting the organization and coaching relationship
* Disable each widget until selected in a top --> bottom order
* Change the button to read "Join"

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="1213" alt="Screenshot 2024-06-17 at 10 11 37" src="https://github.com/Jim-Hodapp-Coaching/refactor-platform-fe/assets/3219120/a15727e7-5d5c-481b-a229-17501e39e25e">


### Testing Strategy
1. Log in which will navigate you to the dashboard automatically, observe the UI changes mentioned
2. Make a selection of organization, notice that coaching relationship select box enables
3. Make a selection of coaching relationship, notice that the coaching session select box enables
4. Make a selection of coaching session, notice that the "Join" button enables


### Concerns
None