### PR TITLE
Fetch all coaching relationships for the current user by organization id

### DIFF
--- a/src/lib/api/coaching-relationships.ts
+++ b/src/lib/api/coaching-relationships.ts
@@ -6,49 +6,45 @@ import { CoachingRelationshipWithUserNames,
             isCoachingRelationshipWithUserNamesArray
         } from "@/types/coaching_relationship_with_user_names";
 import { Id } from "@/types/general";
-import { AxiosError, AxiosResponse } from "axios";
+import axios, { AxiosError, AxiosResponse, AxiosStatic } from "axios";
 
 export const fetchCoachingRelationshipsWithUserNames = async (
     organizationId: Id
   ): Promise<[CoachingRelationshipWithUserNames[], string]> => {
-    const axios = require("axios");
-  
+    const baseUrl = `http://localhost:4000/organizations/${organizationId}/coaching_relationships`;
+    const config = {
+      withCredentials: true,
+      timeout: 5000,
+      headers: {
+        "X-Version": "0.0.1",
+      },
+    };
     var relationships: CoachingRelationshipWithUserNames[] = defaultCoachingRelationshipsWithUserNames();
     var err: string = "";
-  
-    const data = await axios
-      .get(`http://localhost:4000/organizations/${organizationId}/coaching_relationships`, {
-        withCredentials: true,
-        setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
-        headers: {
-          "X-Version": "0.0.1",
-        },
-      })
-      .then(function (response: AxiosResponse) {
-        // handle success
-        console.debug(response);
-        if (isCoachingRelationshipWithUserNamesArray(response.data.data)) {
-          relationships = response.data.data;
-          console.debug(
-            `CoachingRelationshipsWithUserNames: ` + coachingRelationshipsWithUserNamesToString(relationships) + `.`
-          );
-        }
-      })
-      .catch(function (error: AxiosError) {
-        // handle error
-        console.error(error.response?.status);
-        if (error.response?.status == 401) {
-          console.error("Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.");
-          err = "Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.";
-        } else {
-          console.log(error);
-          console.error(
-            `Retrieval of CoachingRelationshipsWithUserNames by organization Id (` + organizationId + `) failed.`
-          );
-          err =
-            `Retrieval of CoachingRealtionshipsWithUserNames by organization Id (` + organizationId + `) failed.`;
-        }
-      });
-  
+
+    try {
+      const response: AxiosResponse = await axios.get(baseUrl, config);
+      console.debug(`AxiosResponse: ${response}`);
+
+      if(isCoachingRelationshipWithUserNamesArray(response.data.data)) {
+        relationships = response.data.data;
+        console.debug(`CoachingRelationshipsWithUserNames: ${coachingRelationshipsWithUserNamesToString(relationships)}.`);
+      }
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      console.error(axiosError.response?.status);
+
+      if(axiosError.response?.status === 401) {
+        console.error("Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.");
+        err = "Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.";
+      } else {
+        console.log(error);
+        console.error(
+          `Retrieval of CoachingRelationshipsWithUserNames by organization Id (` + organizationId + `) failed.`
+        );
+        err =
+          `Retrieval of CoachingRelationshipsWithUserNames by organization Id (` + organizationId + `) failed.`;
+      }
+    } 
     return [relationships, err];
   };

--- a/src/lib/api/coaching-relationships.ts
+++ b/src/lib/api/coaching-relationships.ts
@@ -1,1 +1,54 @@
 // Interacts with the coaching_relationship endpoints
+
+import { CoachingRelationshipWithUserNames,
+            coachingRelationshipsWithUserNamesToString,
+            defaultCoachingRelationshipsWithUserNames,
+            isCoachingRelationshipWithUserNamesArray
+        } from "@/types/coaching_relationship_with_user_names";
+import { Id } from "@/types/general";
+import { AxiosError, AxiosResponse } from "axios";
+
+export const fetchCoachingRelationshipsWithUserNames = async (
+    organizationId: Id
+  ): Promise<[CoachingRelationshipWithUserNames[], string]> => {
+    const axios = require("axios");
+  
+    var relationships: CoachingRelationshipWithUserNames[] = defaultCoachingRelationshipsWithUserNames();
+    var err: string = "";
+  
+    const data = await axios
+      .get(`http://localhost:4000/organizations/${organizationId}/coaching_relationships`, {
+        withCredentials: true,
+        setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
+        headers: {
+          "X-Version": "0.0.1",
+        },
+      })
+      .then(function (response: AxiosResponse) {
+        // handle success
+        console.debug(response);
+        if (isCoachingRelationshipWithUserNamesArray(response.data.data)) {
+          relationships = response.data.data;
+          console.debug(
+            `CoachingRelationshipsWithUserNames: ` + coachingRelationshipsWithUserNamesToString(relationships) + `.`
+          );
+        }
+      })
+      .catch(function (error: AxiosError) {
+        // handle error
+        console.error(error.response?.status);
+        if (error.response?.status == 401) {
+          console.error("Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.");
+          err = "Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.";
+        } else {
+          console.log(error);
+          console.error(
+            `Retrieval of CoachingRelationshipsWithUserNames by organization Id (` + organizationId + `) failed.`
+          );
+          err =
+            `Retrieval of CoachingRealtionshipsWithUserNames by organization Id (` + organizationId + `) failed.`;
+        }
+      });
+  
+    return [relationships, err];
+  };

--- a/src/lib/api/coaching-relationships.ts
+++ b/src/lib/api/coaching-relationships.ts
@@ -1,40 +1,44 @@
 // Interacts with the coaching_relationship endpoints
 
-import { CoachingRelationshipWithUserNames,
-            coachingRelationshipsWithUserNamesToString,
-            defaultCoachingRelationshipsWithUserNames,
-            isCoachingRelationshipWithUserNamesArray
-        } from "@/types/coaching_relationship_with_user_names";
+import {
+  CoachingRelationshipWithUserNames,
+  coachingRelationshipsWithUserNamesToString,
+  defaultCoachingRelationshipsWithUserNames,
+  isCoachingRelationshipWithUserNamesArray
+} from "@/types/coaching_relationship_with_user_names";
 import { Id } from "@/types/general";
-import axios, { AxiosError, AxiosResponse, AxiosStatic } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 
 export const fetchCoachingRelationshipsWithUserNames = async (
-    organizationId: Id
-  ): Promise<[CoachingRelationshipWithUserNames[], string]> => {
-    const baseUrl = `http://localhost:4000/organizations/${organizationId}/coaching_relationships`;
-    const config = {
+  organizationId: Id
+): Promise<[CoachingRelationshipWithUserNames[], string]> => {
+  const axios = require("axios");
+
+  var relationships: CoachingRelationshipWithUserNames[] = defaultCoachingRelationshipsWithUserNames();
+  var err: string = "";
+
+  const data = await axios
+    .get(`http://localhost:4000/organizations/${organizationId}/coaching_relationships`, {
       withCredentials: true,
-      timeout: 5000,
+      setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
       headers: {
         "X-Version": "0.0.1",
       },
-    };
-    var relationships: CoachingRelationshipWithUserNames[] = defaultCoachingRelationshipsWithUserNames();
-    var err: string = "";
-
-    try {
-      const response: AxiosResponse = await axios.get(baseUrl, config);
-      console.debug(`AxiosResponse: ${response}`);
-
-      if(isCoachingRelationshipWithUserNamesArray(response.data.data)) {
+    })
+    .then(function (response: AxiosResponse) {
+      // handle success
+      console.debug(response);
+      if (isCoachingRelationshipWithUserNamesArray(response.data.data)) {
         relationships = response.data.data;
-        console.debug(`CoachingRelationshipsWithUserNames: ${coachingRelationshipsWithUserNamesToString(relationships)}.`);
+        console.debug(
+          `CoachingRelationshipsWithUserNames: ` + coachingRelationshipsWithUserNamesToString(relationships) + `.`
+        );
       }
-    } catch (error) {
-      const axiosError = error as AxiosError;
-      console.error(axiosError.response?.status);
-
-      if(axiosError.response?.status === 401) {
+    })
+    .catch(function (error: AxiosError) {
+      // handle error
+      console.error(error.response?.status);
+      if (error.response?.status == 401) {
         console.error("Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.");
         err = "Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.";
       } else {
@@ -43,8 +47,9 @@ export const fetchCoachingRelationshipsWithUserNames = async (
           `Retrieval of CoachingRelationshipsWithUserNames by organization Id (` + organizationId + `) failed.`
         );
         err =
-          `Retrieval of CoachingRelationshipsWithUserNames by organization Id (` + organizationId + `) failed.`;
+          `Retrieval of CoachingRealtionshipsWithUserNames by organization Id (` + organizationId + `) failed.`;
       }
-    } 
-    return [relationships, err];
-  };
+    });
+
+  return [relationships, err];
+};

--- a/src/types/coaching_relationship_with_user_names.ts
+++ b/src/types/coaching_relationship_with_user_names.ts
@@ -1,0 +1,66 @@
+import { DateTime } from "ts-luxon";
+import { Id } from "@/types/general";
+
+// This must always reflect the Rust struct on the backend
+// entity_api::coaching_relationship::CoachingRelationshipWithUserNames
+export interface CoachingRelationshipWithUserNames {
+  id: Id;
+  coach_id: Id;
+  coachee_id: Id;
+  coach_first_name: String;
+  coach_last_name: String;
+  coachee_first_name: String;
+  coachee_last_name: String;
+  created_at: DateTime;
+  updated_at: DateTime;
+}
+
+export function isCoachingRelationshipWithUserNames(value: unknown): value is CoachingRelationshipWithUserNames {
+    if (!value || typeof value !== "object") {
+      return false;
+    }
+    const object = value as Record<string, unknown>;
+  
+    return (
+      typeof object.id === "string" &&
+      typeof object.coach_id === "string" &&
+      typeof object.coachee_id === "string" &&
+      typeof object.coach_first_name === "string" &&
+      typeof object.coach_last_name === "string" &&
+      typeof object.coachee_first_name === "string" &&
+      typeof object.coachee_last_name === "string" &&
+      typeof object.created_at === "string" &&
+      typeof object.updated_at === "string"
+    );
+  }
+
+export function isCoachingRelationshipWithUserNamesArray(value: unknown): value is CoachingRelationshipWithUserNames[] {
+  return Array.isArray(value) && value.every(isCoachingRelationshipWithUserNames);
+}
+
+export function defaultCoachingRelationshipWithUserNames(): CoachingRelationshipWithUserNames {
+    var now = DateTime.now();
+    return {
+      id: "",
+      coach_id: "",
+      coachee_id: "",
+      coach_first_name: "",
+      coach_last_name: "",
+      coachee_first_name: "",
+      coachee_last_name: "",
+      created_at: now,
+      updated_at: now,
+    };
+  }
+  
+  export function defaultOrganizations(): CoachingRelationshipWithUserNames[] {
+    return [defaultCoachingRelationshipWithUserNames()];
+  }
+  
+  export function organizationToString(relationship: CoachingRelationshipWithUserNames): string {
+    return JSON.stringify(relationship);
+  }
+  
+  export function organizationsToString(relationships: CoachingRelationshipWithUserNames[]): string {
+    return JSON.stringify(relationships);
+  }

--- a/src/types/coaching_relationship_with_user_names.ts
+++ b/src/types/coaching_relationship_with_user_names.ts
@@ -53,14 +53,14 @@ export function defaultCoachingRelationshipWithUserNames(): CoachingRelationship
     };
   }
   
-  export function defaultOrganizations(): CoachingRelationshipWithUserNames[] {
+  export function defaultCoachingRelationshipsWithUserNames(): CoachingRelationshipWithUserNames[] {
     return [defaultCoachingRelationshipWithUserNames()];
   }
   
-  export function organizationToString(relationship: CoachingRelationshipWithUserNames): string {
+  export function coachingRelationshipWithUserNamesToString(relationship: CoachingRelationshipWithUserNames): string {
     return JSON.stringify(relationship);
   }
   
-  export function organizationsToString(relationships: CoachingRelationshipWithUserNames[]): string {
+  export function coachingRelationshipsWithUserNamesToString(relationships: CoachingRelationshipWithUserNames[]): string {
     return JSON.stringify(relationships);
   }


### PR DESCRIPTION
## Description
This PR adds to the CoachingSessionSelector the ability to fetch the associated coaching relationships the current user can select from under their chosen organization.


#### GitHub Issue: N/A

### Changes
* Loads the associated coaching relationships in the second select after selecting an organization in the first select

### Screenshots / Videos Showing UI Changes (if applicable)

Initial state:
<img width="510" alt="Screenshot 2024-06-26 at 21 32 46" src="https://github.com/Jim-Hodapp-Coaching/refactor-platform-fe/assets/3219120/1ea604a8-212c-4030-a346-403c3ca80082">

First selected organization:
<img width="506" alt="Screenshot 2024-06-26 at 21 33 14" src="https://github.com/Jim-Hodapp-Coaching/refactor-platform-fe/assets/3219120/b177b8f5-c349-438b-a0c2-b61fcf0b00c6">

Second selected organization:
<img width="506" alt="Screenshot 2024-06-26 at 21 33 31" src="https://github.com/Jim-Hodapp-Coaching/refactor-platform-fe/assets/3219120/fb8938bc-cba5-4733-8bde-25b3787812a3">


### Testing Strategy
1. Log in and the dashboard will show
2. Select an organization
3. Notice that one list of coaching relationships loads
4. Select a different organization
5. Notice that a different list of coaching relationships loads


### Concerns
None