### PR TITLE
Introduce MVP-level coaching session Note creation/updating

### DIFF
--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -98,7 +98,6 @@ export default function CoachingSessionsPage() {
   }, [coachingSessionId, !note]);
 
   const handleInputChange = (value: string) => {
-    setSyncStatus("");
     setNote(value);
 
     if (noteId && coachingSessionId && userId) {
@@ -115,6 +114,10 @@ export default function CoachingSessionsPage() {
           console.error("Failed to update Note: " + err);
         });
     }
+  };
+
+  const handleKeyDown = (value: string) => {
+    setSyncStatus("");
   };
 
   return (
@@ -224,6 +227,7 @@ export default function CoachingSessionsPage() {
                     <CoachingNotes
                       value={note}
                       onChange={handleInputChange}
+                      onKeyDown={handleKeyDown}
                     ></CoachingNotes>
                     <p className="text-sm text-muted-foreground">
                       {syncStatus}
@@ -268,7 +272,8 @@ export default function CoachingSessionsPage() {
 const CoachingNotes: React.FC<{
   value: string;
   onChange: (value: string) => void;
-}> = ({ value, onChange }) => {
+  onKeyDown: () => void;
+}> = ({ value, onChange, onKeyDown }) => {
   const WAIT_INTERVAL = 1000;
   const [timer, setTimer] = useState<number | undefined>(undefined);
   const [note, setNote] = useState<string>(value);
@@ -296,6 +301,10 @@ const CoachingNotes: React.FC<{
     setTimer(newTimer);
   };
 
+  const handleOnKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    onKeyDown();
+  };
+
   useEffect(() => {
     return () => {
       if (timer) {
@@ -310,6 +319,7 @@ const CoachingNotes: React.FC<{
       value={note}
       className="p-4 min-h-[400px] md:min-h-[630px] lg:min-h-[630px]"
       onChange={handleSessionNoteChange}
+      onKeyDown={handleOnKeyDown}
     />
   );
 };

--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -116,7 +116,7 @@ export default function CoachingSessionsPage() {
     }
   };
 
-  const handleKeyDown = (value: string) => {
+  const handleKeyDown = () => {
     setSyncStatus("");
   };
 

--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -39,6 +39,9 @@ import { cn } from "@/lib/utils";
 import { models, types } from "@/data/models";
 import { current, future, past } from "@/data/presets";
 import { useAppStateStore } from "@/lib/providers/app-state-store-provider";
+import { useEffect, useState } from "react";
+import { createNote } from "@/lib/api/notes";
+import { noteToString } from "@/types/note";
 //import { useAuthStore } from "@/lib/providers/auth-store-provider";
 
 // export const metadata: Metadata = {
@@ -47,10 +50,30 @@ import { useAppStateStore } from "@/lib/providers/app-state-store-provider";
 // };
 
 export default function CoachingSessionsPage() {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [noteId, setNoteId] = useState("");
   //const { isLoggedIn, userId } = useAuthStore((state) => state);
   const { organizationId, relationshipId, coachingSessionId } =
     useAppStateStore((state) => state);
+
+  useEffect(() => {
+    async function createEmptyNote() {
+      if (!coachingSessionId) return;
+
+      await createNote(coachingSessionId, "")
+        .then((note) => {
+          // Apparently it's normal for this to be triggered twice in modern
+          // React versions in strict + development modes
+          // https://stackoverflow.com/questions/60618844/react-hooks-useeffect-is-called-twice-even-if-an-empty-array-is-used-as-an-ar
+          console.debug("note: " + noteToString(note));
+          setNoteId(note.id);
+        })
+        .catch((err) => {
+          console.error("Failed to create empty Note: " + err);
+        });
+    }
+    createEmptyNote();
+  }, [coachingSessionId, !noteId]);
 
   return (
     <>

--- a/src/lib/api/notes.ts
+++ b/src/lib/api/notes.ts
@@ -1,0 +1,61 @@
+// Interacts with the note endpoints
+
+import { Id } from "@/types/general";
+import { defaultNote, isNote, Note, noteToString, parseNote } from "@/types/note";
+import { AxiosError, AxiosResponse } from "axios";
+
+export const createNote = async (
+    coaching_session_id: Id,
+    body: string
+  ): Promise<Note> => {
+    const axios = require("axios");
+  
+    //var bodyJSON: String = JSON.stringify('"body": "' + body + '"');
+    const bodyJson = {
+        body: body
+    };
+    // A full real note to be returned from the backend with the same body
+    var createdNote: Note = defaultNote();
+    var err: string = "";
+  
+    //var strNote: string = noteToString(note);
+    const data = await axios
+      .post(`http://localhost:4000/notes`, bodyJson, {
+        withCredentials: true,
+        setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
+        headers: {
+          "X-Version": "0.0.1",
+          "Content-Type": "application/json",
+        },
+      })
+      .then(function (response: AxiosResponse) {
+        // handle success
+        const noteStr = response.data.data;
+        if (isNote(noteStr)) {
+          createdNote = parseNote(noteStr);
+        }
+      })
+      .catch(function (error: AxiosError) {
+        // handle error
+        console.error(error.response?.status);
+        if (error.response?.status == 401) {
+          console.error("Creation of Note failed: unauthorized.");
+          err = "Creation of Note failed: unauthorized.";
+        } else if (error.response?.status == 500) {
+          console.error(
+            "Creation of Note failed: internal server error."
+          );
+          err = "Creation of Note failed: internal server error.";
+        } else {
+          console.log(error);
+          console.error(`Creation of new Note failed.`);
+          err = `Creation of new Note failed.`;
+        }
+      }
+    );
+    
+    if (err)
+      throw err;
+  
+    return createdNote;
+  };

--- a/src/lib/api/notes.ts
+++ b/src/lib/api/notes.ts
@@ -1,26 +1,84 @@
 // Interacts with the note endpoints
 
 import { Id } from "@/types/general";
-import { defaultNote, isNote, Note, noteToString, parseNote } from "@/types/note";
+import { defaultNote, isNote, isNoteArray, Note, noteToString, parseNote } from "@/types/note";
 import { AxiosError, AxiosResponse } from "axios";
+
+export const fetchNotesByCoachingSessionId = async (
+    coachingSessionId: Id
+  ): Promise<Note[]> => {
+    const axios = require("axios");
+  
+    var notes: Note[] = [];
+    var err: string = "";
+  
+    const data = await axios
+      .get(`http://localhost:4000/notes`, {
+        params: {
+          coaching_session_id: coachingSessionId,
+        },
+        withCredentials: true,
+        setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
+        headers: {
+          "X-Version": "0.0.1",
+        },
+      })
+      .then(function (response: AxiosResponse) {
+        // handle success
+        if (response?.status == 204) {
+            console.error("Retrieval of Note failed: no content.");
+            err = "Retrieval of Note failed: no content.";
+        } else {
+            var notes_data = response.data.data;
+            if (isNoteArray(notes_data)) {
+                notes_data.forEach((note_data: any) => {
+                    notes.push(parseNote(note_data))
+                });
+            }
+        }
+      })
+      .catch(function (error: AxiosError) {
+        // handle error
+        console.error(error.response?.status);
+        if (error.response?.status == 401) {
+          console.error("Retrieval of Note failed: unauthorized.");
+          err = "Retrieval of Note failed: unauthorized.";
+        } else {
+          console.log(error);
+          console.error(
+            `Retrieval of Note by coaching session Id (` + coachingSessionId + `) failed.`
+          );
+          err =
+            `Retrieval of Note by coaching session Id (` + coachingSessionId + `) failed.`;
+        }
+      });
+
+    if (err)
+      throw err;
+  
+    return notes;
+  };
 
 export const createNote = async (
     coaching_session_id: Id,
+    user_id: Id,
     body: string
   ): Promise<Note> => {
     const axios = require("axios");
   
-    //var bodyJSON: String = JSON.stringify('"body": "' + body + '"');
-    const bodyJson = {
+    const newNoteJson = {
+        coaching_session_id: coaching_session_id,
+        user_id: user_id,
         body: body
     };
+    console.debug("newNoteJson: " + JSON.stringify(newNoteJson));
     // A full real note to be returned from the backend with the same body
     var createdNote: Note = defaultNote();
     var err: string = "";
   
     //var strNote: string = noteToString(note);
     const data = await axios
-      .post(`http://localhost:4000/notes`, bodyJson, {
+      .post(`http://localhost:4000/notes`, newNoteJson, {
         withCredentials: true,
         setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
         headers: {
@@ -58,4 +116,58 @@ export const createNote = async (
       throw err;
   
     return createdNote;
+  };
+
+  export const updateNote = async (
+    id: Id,
+    user_id: Id,
+    coaching_session_id: Id,
+    body: string,
+  ): Promise<Note> => {
+    const axios = require("axios");
+  
+    var updatedNote: Note = defaultNote();
+    var err: string = "";
+  
+    const newNoteJson = {
+        coaching_session_id: coaching_session_id,
+        user_id: user_id,
+        body: body
+    };
+
+    const data = await axios
+      .put(`http://localhost:4000/notes/${id}`, newNoteJson, {
+        withCredentials: true,
+        setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
+        headers: {
+          "X-Version": "0.0.1",
+          "Content-Type": "application/json",
+        },
+      })
+      .then(function (response: AxiosResponse) {
+        // handle success
+        if (isNote(response.data.data)) {
+          updatedNote = response.data.data;
+        }
+      })
+      .catch(function (error: AxiosError) {
+        // handle error
+        console.error(error.response?.status);
+        if (error.response?.status == 401) {
+          console.error("Update of Note failed: unauthorized.");
+          err = "Update of Organization failed: unauthorized.";
+        } else if (error.response?.status == 500) {
+          console.error("Update of Organization failed: internal server error.");
+          err = "Update of Organization failed: internal server error.";
+        } else {
+          console.log(error);
+          console.error(`Update of new Organization failed.`);
+          err = `Update of new Organization failed.`;
+        }
+      });
+
+    if (err)
+      throw err;
+  
+    return updatedNote;
   };

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -6,7 +6,7 @@ import { Id, SortOrder } from "@/types/general";
 export interface Note {
   id: Id;
   coaching_session_id: Id,
-  body: String,
+  body: string,
   user_id: Id,
   created_at: DateTime;
   updated_at: DateTime;

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -1,0 +1,85 @@
+import { DateTime } from "ts-luxon";
+import { Id, SortOrder } from "@/types/general";
+
+// This must always reflect the Rust struct on the backend
+// entity::notes::Model
+export interface Note {
+  id: Id;
+  coaching_session_id: Id,
+  body: String,
+  user_id: Id,
+  created_at: DateTime;
+  updated_at: DateTime;
+}
+
+// The main purpose of having this parsing function is to be able to parse the
+// returned DateTimeWithTimeZone (Rust type) string into something that ts-luxon
+// will agree to work with internally.
+export function parseNote(data: any): Note {
+  if (!isNote(data)) {
+    throw new Error('Invalid Note data');
+  }
+  return {
+    id: data.id,
+    coaching_session_id: data.coaching_session_id,
+    body: data.body,
+    user_id: data.user_id,
+    created_at: DateTime.fromISO(data.created_at.toString()),
+    updated_at: DateTime.fromISO(data.updated_at.toString()),
+  };
+}
+
+export function isNote(value: unknown): value is Note {
+    if (!value || typeof value !== "object") {
+      return false;
+    }
+    const object = value as Record<string, unknown>;
+  
+    return (
+      typeof object.id === "string" &&
+      typeof object.coaching_session_id === "string" &&
+      typeof object.body === "string" &&
+      typeof object.user_id === "string" &&
+      typeof object.created_at === "string" &&
+      typeof object.updated_at === "string"
+    );
+  }
+
+export function isNoteArray(value: unknown): value is Note[] {
+  return Array.isArray(value) && value.every(isNote);
+}
+
+export function sortNoteArray(notes: Note[], order: SortOrder): Note[] {
+  if (order == SortOrder.Ascending) {
+    notes.sort((a, b) => 
+      new Date(a.updated_at.toString()).getTime() - new Date(b.updated_at.toString()).getTime());
+  } else if (order == SortOrder.Descending) {
+    notes.sort((a, b) => 
+      new Date(b.updated_at.toString()).getTime() - new Date(a.updated_at.toString()).getTime());
+  }
+  return notes;
+}
+
+export function defaultNote(): Note {
+    var now = DateTime.now();
+    return {
+      id: "",
+      coaching_session_id: "",
+      body: "",
+      user_id: "",
+      created_at: now,
+      updated_at: now,
+    };
+  }
+  
+  export function defaultNotes(): Note[] {
+    return [defaultNote()];
+  }
+  
+  export function noteToString(note: Note): string {
+    return JSON.stringify(note);
+  }
+  
+  export function notesToString(notes: Note[]): string {
+    return JSON.stringify(notes);
+  }


### PR DESCRIPTION
## Description
This PR creates a new note when a coaching session page first loads and an associated note.id isn't yet set. It also updates the singular Note (for now) associated with this session after a 1 second delay of non-typing.

**Note:** this requires the use of this [backend PR](https://github.com/Jim-Hodapp-Coaching/refactor-platform-rs/pull/57) to function correctly

#### GitHub Issue: None

### Changes
* Introduces a new `Note` type
* Create a new Note instance if there isn't one yet for the given `coaching_session_id`
* Fetches the Note's body on page render if there is an instance already associated with the given `coaching_session_id`
* Updates the Note's body on the backend if the user types any changes

### Screenshots / Videos Showing UI Changes (if applicable)


### Testing Strategy
1. Join a coaching session
2. Observe the Note body text in the textarea if there is already Note text associated with this session
3. Update the text, notice that a text indicator below the note textarea says "All change saved" if it was able to update the backend, otherwise should say "Failed to save changes" if it couldn't update the backend


### Concerns
This PR does not yet automatically update the second user's Note textarea when the first user makes any changes. I haven't tested this across multiple users yet, they will most likely clobber each other's updates if they both make Note changes.