### PR TITLE
Greatly improve the fetch/create/update Note handlers logic

### DIFF
--- a/src/lib/api/notes.ts
+++ b/src/lib/api/notes.ts
@@ -25,16 +25,11 @@ export const fetchNotesByCoachingSessionId = async (
       })
       .then(function (response: AxiosResponse) {
         // handle success
-        if (response?.status == 204) {
-            console.error("Retrieval of Note failed: no content.");
-            err = "Retrieval of Note failed: no content.";
-        } else {
-            var notes_data = response.data.data;
-            if (isNoteArray(notes_data)) {
-                notes_data.forEach((note_data: any) => {
-                    notes.push(parseNote(note_data))
-                });
-            }
+        var notes_data = response.data.data;
+        if (isNoteArray(notes_data)) {
+            notes_data.forEach((note_data: any) => {
+                notes.push(parseNote(note_data))
+            });
         }
       })
       .catch(function (error: AxiosError) {
@@ -43,6 +38,9 @@ export const fetchNotesByCoachingSessionId = async (
         if (error.response?.status == 401) {
           console.error("Retrieval of Note failed: unauthorized.");
           err = "Retrieval of Note failed: unauthorized.";
+        } else if (error.response?.status == 404) {
+          console.error("Retrieval of Note failed: Note by coaching session Id (" + coachingSessionId + ") not found.");
+          err = "Retrieval of Note failed: Note by coaching session Id (" + coachingSessionId + ") not found.";
         } else {
           console.log(error);
           console.error(


### PR DESCRIPTION
## Description
This PR greatly improves and fixes the fetch/create/update Note handlers logic on the coaching session page.

**Note:** this PR requires that you use the following [backend branch](https://github.com/Jim-Hodapp-Coaching/refactor-platform-rs/pull/62)

#### GitHub Issue: N/A

### Changes
* Move the `createNote()` method into the `handlerInputChange()` event handler alongside `updateNote()`
* Ensure the fetch Note `useEffect()` logic works correctly in dev and prod modes since React calls the setup method twice in dev mode and once in prod mode
* Handle an empty array of Notes returned by the backend (this is not a 404 error case)

### Screenshots / Videos Showing UI Changes (if applicable)
N/A

### Testing Strategy
1. Open up the JS console in your browser to observe debug/error statements
2. Login and select a coaching session to join
3. Notice that no Note is displayed in the textarea by default
4. Now type some text into the textarea and observe that you see a trace statement "Newly created Note: ..."
5. Click the R Refactor logo in the upper right hand corner of the screen to return to the dashboard page
6. Select and join the same coaching session, notice that the Note's contents show up in the textarea
7. Make an update to the notes and navigate out of the session and back in like in step 5. Observe that the updated Note's contents show up in the textarea


### Concerns
None