### PR TITLE
Set dynamic coaching session titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "cmdk": "^0.2.1",
-        "date-fns": "^3.3.1",
         "lucide-react": "^0.314.0",
         "next": "^14.2.3",
         "next-themes": "^0.2.1",
@@ -2756,6 +2755,8 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "cmdk": "^0.2.1",
-    "date-fns": "^3.3.1",
     "lucide-react": "^0.314.0",
     "next": "^14.2.3",
     "next-themes": "^0.2.1",

--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -231,7 +231,7 @@ export default function CoachingSessionsPage() {
             coachingSession={coachingSession}
             coachingRelationship={coachingRelationship}
             locale={siteConfig.locale}
-            style={SessionTitleStyle.CoachFirstCoacheeFirstDate}
+            style={siteConfig.titleStyle}
             onRender={handleTitleRender}
           ></CoachingSessionTitle>
           <div className="ml-auto flex w-full space-x-2 sm:justify-end">

--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -61,7 +61,6 @@ import { Action } from "@/types/action";
 import { createAction, deleteAction, updateAction } from "@/lib/api/actions";
 import { DateTime } from "ts-luxon";
 import { CoachingSessionTitle } from "@/components/ui/coaching-sessions/coaching-session-title";
-import { SessionTitle, SessionTitleStyle } from "@/types/session-title";
 
 // export const metadata: Metadata = {
 //   title: "Coaching Session",
@@ -228,8 +227,6 @@ export default function CoachingSessionsPage() {
       <div className="h-full flex-col md:flex">
         <div className="flex flex-col items-start justify-between space-y-2 py-4 px-4 sm:flex-row sm:items-center sm:space-y-0 md:h-16">
           <CoachingSessionTitle
-            coachingSession={coachingSession}
-            coachingRelationship={coachingRelationship}
             locale={siteConfig.locale}
             style={siteConfig.titleStyle}
             onRender={handleTitleRender}

--- a/src/components/ui/coaching-sessions/actions-list.tsx
+++ b/src/components/ui/coaching-sessions/actions-list.tsx
@@ -201,7 +201,12 @@ const ActionsList: React.FC<{
 
   useEffect(() => {
     async function loadActions() {
-      if (!coachingSessionId) return;
+      if (!coachingSessionId) {
+        console.error(
+          "Failed to fetch Actions since coachingSession.id is not set."
+        );
+        return;
+      }
 
       await fetchActionsByCoachingSessionId(coachingSessionId)
         .then((actions) => {

--- a/src/components/ui/coaching-sessions/agreements-list.tsx
+++ b/src/components/ui/coaching-sessions/agreements-list.tsx
@@ -19,12 +19,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { MoreHorizontal, ArrowUpDown, Save } from "lucide-react";
 import { Id } from "@/types/general";
-import {
-  createAgreement,
-  deleteAgreement as deleteAgreementApi,
-  updateAgreement as updateAgreementApi,
-  fetchAgreementsByCoachingSessionId,
-} from "@/lib/api/agreements";
+import { fetchAgreementsByCoachingSessionId } from "@/lib/api/agreements";
 import { Agreement, agreementToString } from "@/types/agreement";
 import { DateTime } from "ts-luxon";
 import { siteConfig } from "@/site.config";
@@ -158,7 +153,12 @@ const AgreementsList: React.FC<{
 
   useEffect(() => {
     async function loadAgreements() {
-      if (!coachingSessionId) return;
+      if (!coachingSessionId) {
+        console.error(
+          "Failed to fetch Agreements since coachingSession.id is not set."
+        );
+        return;
+      }
 
       await fetchAgreementsByCoachingSessionId(coachingSessionId)
         .then((agreements) => {

--- a/src/components/ui/coaching-sessions/coaching-session-title.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-title.tsx
@@ -36,7 +36,7 @@ const CoachingSessionTitle: React.FC<{
 
   return (
     <h4 className="font-semibold break-words w-full px-2 md:px-4 lg:px-6 md:text-clip">
-      {sessionTitle?.title}
+      {sessionTitle ? sessionTitle.title : "Untitled Session"}
     </h4>
   );
 };

--- a/src/components/ui/coaching-sessions/coaching-session-title.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-title.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  generateSessionTitle,
+  SessionTitle,
+  SessionTitleStyle,
+} from "@/types/session-title";
+import { CoachingRelationshipWithUserNames } from "@/types/coaching_relationship_with_user_names";
+import { CoachingSession } from "@/types/coaching-session";
+
+const CoachingSessionTitle: React.FC<{
+  coachingSession: CoachingSession;
+  coachingRelationship: CoachingRelationshipWithUserNames;
+  locale: string | "us";
+  style: SessionTitleStyle;
+  onRender: (sessionTitle: string) => void;
+}> = ({ coachingSession, coachingRelationship, locale, style, onRender }) => {
+  const [sessionTitle, setSessionTitle] = useState<SessionTitle>();
+
+  useEffect(() => {
+    async function getSessionTitle() {
+      const sessionTitle = generateSessionTitle(
+        coachingSession,
+        coachingRelationship,
+        style,
+        locale
+      );
+      setSessionTitle(sessionTitle);
+      console.debug("sessionTitle: " + JSON.stringify(sessionTitle));
+      onRender(sessionTitle.title);
+    }
+
+    getSessionTitle();
+  }, [coachingSession, coachingRelationship]);
+
+  return (
+    <h4 className="font-semibold break-words w-full px-2 md:px-4 lg:px-6 md:text-clip">
+      {sessionTitle?.title}
+    </h4>
+  );
+};
+
+export { CoachingSessionTitle };

--- a/src/components/ui/coaching-sessions/coaching-session-title.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-title.tsx
@@ -2,41 +2,58 @@
 
 import { useEffect, useState } from "react";
 import {
+  defaultSessionTitle,
   generateSessionTitle,
   SessionTitle,
   SessionTitleStyle,
 } from "@/types/session-title";
-import { CoachingRelationshipWithUserNames } from "@/types/coaching_relationship_with_user_names";
-import { CoachingSession } from "@/types/coaching-session";
+import {
+  CoachingRelationshipWithUserNames,
+  coachingRelationshipWithUserNamesToString,
+} from "@/types/coaching_relationship_with_user_names";
+import {
+  CoachingSession,
+  coachingSessionToString,
+} from "@/types/coaching-session";
+import { useAppStateStore } from "@/lib/providers/app-state-store-provider";
 
 const CoachingSessionTitle: React.FC<{
-  coachingSession: CoachingSession;
-  coachingRelationship: CoachingRelationshipWithUserNames;
   locale: string | "us";
   style: SessionTitleStyle;
   onRender: (sessionTitle: string) => void;
-}> = ({ coachingSession, coachingRelationship, locale, style, onRender }) => {
+}> = ({ locale, style, onRender }) => {
+  const [isLoading, setIsLoading] = useState(true);
   const [sessionTitle, setSessionTitle] = useState<SessionTitle>();
+  const { coachingSession, coachingRelationship } = useAppStateStore(
+    (state) => state
+  );
+  useState<CoachingRelationshipWithUserNames>();
 
   useEffect(() => {
-    async function getSessionTitle() {
-      const sessionTitle = generateSessionTitle(
+    if (coachingSession && coachingRelationship) {
+      setIsLoading(false);
+      const title = generateSessionTitle(
         coachingSession,
         coachingRelationship,
         style,
         locale
       );
-      setSessionTitle(sessionTitle);
-      console.debug("sessionTitle: " + JSON.stringify(sessionTitle));
-      onRender(sessionTitle.title);
+      setSessionTitle(title);
+      onRender(title.title);
     }
+  }, [coachingSession, coachingRelationship, style, locale, onRender]);
 
-    getSessionTitle();
-  }, [coachingSession, coachingRelationship]);
+  if (isLoading) {
+    return (
+      <h4 className="font-semibold break-words w-full px-2 md:px-4 lg:px-6 md:text-clip">
+        {defaultSessionTitle().title}
+      </h4>
+    );
+  }
 
   return (
     <h4 className="font-semibold break-words w-full px-2 md:px-4 lg:px-6 md:text-clip">
-      {sessionTitle ? sessionTitle.title : "Untitled Session"}
+      {sessionTitle ? sessionTitle.title : defaultSessionTitle().title}
     </h4>
   );
 };

--- a/src/components/ui/dashboard/select-coaching-session.tsx
+++ b/src/components/ui/dashboard/select-coaching-session.tsx
@@ -33,7 +33,7 @@ import {
   coachingRelationshipWithUserNamesToString,
   getCoachingRelationshipById,
 } from "@/types/coaching_relationship_with_user_names";
-import { Id } from "@/types/general";
+import { getDateTimeFromString, Id } from "@/types/general";
 import { Organization } from "@/types/organization";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -220,7 +220,6 @@ export function SelectCoachingSession({
             defaultValue="today"
             disabled={!relationshipId}
             value={coachingSessionId}
-            // TODO: set CoachingSession in the app state!!
             onValueChange={handleSetCoachingSession}
           >
             <SelectTrigger id="session">
@@ -228,29 +227,41 @@ export function SelectCoachingSession({
             </SelectTrigger>
             <SelectContent>
               {coachingSessions.some(
-                (session) => session.date < DateTime.now()
+                (session) =>
+                  getDateTimeFromString(session.date) < DateTime.now()
               ) && (
                 <SelectGroup>
                   <SelectLabel>Previous Sessions</SelectLabel>
                   {coachingSessions
-                    .filter((session) => session.date < DateTime.now())
+                    .filter(
+                      (session) =>
+                        getDateTimeFromString(session.date) < DateTime.now()
+                    )
                     .map((session) => (
                       <SelectItem value={session.id} key={session.id}>
-                        {session.date.toLocaleString(DateTime.DATETIME_FULL)}
+                        {getDateTimeFromString(session.date).toLocaleString(
+                          DateTime.DATETIME_FULL
+                        )}
                       </SelectItem>
                     ))}
                 </SelectGroup>
               )}
               {coachingSessions.some(
-                (session) => session.date >= DateTime.now()
+                (session) =>
+                  getDateTimeFromString(session.date) >= DateTime.now()
               ) && (
                 <SelectGroup>
                   <SelectLabel>Upcoming Sessions</SelectLabel>
                   {coachingSessions
-                    .filter((session) => session.date >= DateTime.now())
+                    .filter(
+                      (session) =>
+                        getDateTimeFromString(session.date) >= DateTime.now()
+                    )
                     .map((session) => (
                       <SelectItem value={session.id} key={session.id}>
-                        {session.date.toLocaleString(DateTime.DATETIME_FULL)}
+                        {getDateTimeFromString(session.date).toLocaleString(
+                          DateTime.DATETIME_FULL
+                        )}
                       </SelectItem>
                     ))}
                 </SelectGroup>

--- a/src/components/ui/dashboard/select-coaching-session.tsx
+++ b/src/components/ui/dashboard/select-coaching-session.tsx
@@ -23,8 +23,16 @@ import { fetchCoachingRelationshipsWithUserNames } from "@/lib/api/coaching-rela
 import { fetchCoachingSessions } from "@/lib/api/coaching-sessions";
 import { fetchOrganizationsByUserId } from "@/lib/api/organizations";
 import { useAppStateStore } from "@/lib/providers/app-state-store-provider";
-import { CoachingSession } from "@/types/coaching-session";
-import { CoachingRelationshipWithUserNames } from "@/types/coaching_relationship_with_user_names";
+import {
+  CoachingSession,
+  coachingSessionToString,
+  getCoachingSessionById,
+} from "@/types/coaching-session";
+import {
+  CoachingRelationshipWithUserNames,
+  coachingRelationshipWithUserNamesToString,
+  getCoachingRelationshipById,
+} from "@/types/coaching_relationship_with_user_names";
 import { Id } from "@/types/general";
 import { Organization } from "@/types/organization";
 import Link from "next/link";
@@ -46,7 +54,13 @@ export function SelectCoachingSession({
   const { relationshipId, setRelationshipId } = useAppStateStore(
     (state) => state
   );
+  const { coachingRelationship, setCoachingRelationship } = useAppStateStore(
+    (state) => state
+  );
   const { coachingSessionId, setCoachingSessionId } = useAppStateStore(
+    (state) => state
+  );
+  const { coachingSession, setCoachingSession } = useAppStateStore(
     (state) => state
   );
 
@@ -115,6 +129,31 @@ export function SelectCoachingSession({
     loadCoachingSessions();
   }, [relationshipId]);
 
+  const handleSetCoachingRelationship = (coachingRelationshipId: string) => {
+    setRelationshipId(coachingRelationshipId);
+    const coachingRelationship = getCoachingRelationshipById(
+      coachingRelationshipId,
+      coachingRelationships
+    );
+    console.debug(
+      "coachingRelationship: " +
+        coachingRelationshipWithUserNamesToString(coachingRelationship)
+    );
+    setCoachingRelationship(coachingRelationship);
+  };
+
+  const handleSetCoachingSession = (coachingSessionId: string) => {
+    setCoachingSessionId(coachingSessionId);
+    const coachingSession = getCoachingSessionById(
+      coachingSessionId,
+      coachingSessions
+    );
+    console.debug(
+      "coachingSession: " + coachingSessionToString(coachingSession)
+    );
+    setCoachingSession(coachingSession);
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -154,7 +193,7 @@ export function SelectCoachingSession({
             defaultValue="caleb"
             disabled={!organizationId}
             value={relationshipId}
-            onValueChange={setRelationshipId}
+            onValueChange={handleSetCoachingRelationship}
           >
             <SelectTrigger id="relationship">
               <SelectValue placeholder="Select coaching relationship" />
@@ -181,7 +220,8 @@ export function SelectCoachingSession({
             defaultValue="today"
             disabled={!relationshipId}
             value={coachingSessionId}
-            onValueChange={setCoachingSessionId}
+            // TODO: set CoachingSession in the app state!!
+            onValueChange={handleSetCoachingSession}
           >
             <SelectTrigger id="session">
               <SelectValue placeholder="Select coaching session" />

--- a/src/lib/api/coaching-relationships.ts
+++ b/src/lib/api/coaching-relationships.ts
@@ -3,11 +3,56 @@
 import {
   CoachingRelationshipWithUserNames,
   coachingRelationshipsWithUserNamesToString,
+  defaultCoachingRelationshipWithUserNames,
   defaultCoachingRelationshipsWithUserNames,
+  isCoachingRelationshipWithUserNames,
   isCoachingRelationshipWithUserNamesArray
 } from "@/types/coaching_relationship_with_user_names";
 import { Id } from "@/types/general";
 import { AxiosError, AxiosResponse } from "axios";
+
+export const fetchCoachingRelationshipWithUserNames = async (
+  organization_id: Id,
+  relationship_id: Id
+): Promise<CoachingRelationshipWithUserNames> => {
+  const axios = require("axios");
+
+  var relationship: CoachingRelationshipWithUserNames = defaultCoachingRelationshipWithUserNames();
+  var err: string = "";
+
+  const data = await axios
+    .get(`http://localhost:4000/organizations/${organization_id}/coaching_relationships/${relationship_id}`, {
+      withCredentials: true,
+      setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
+      headers: {
+        "X-Version": "0.0.1",
+      },
+    })
+    .then(function (response: AxiosResponse) {
+      // handle success
+      if (isCoachingRelationshipWithUserNames(response.data.data)) {
+        relationship = response.data.data;
+      }
+    })
+    .catch(function (error: AxiosError) {
+      // handle error
+      console.error(error.response?.status);
+      if (error.response?.status == 401) {
+        err = "Retrieval of CoachingRelationshipWithUserNames failed: unauthorized.";
+      } else if (error.response?.status == 500) {
+        err = "Retrieval of CoachingRelationshipWithUserNames failed, system error: " + error.response.data;
+      } else {
+        err = `Retrieval of CoachingRelationshipWithUserNames(` + relationship_id + `) failed: ` + error.response?.data;
+      }
+    });
+
+    if (err) {
+      console.error(err);
+      throw err;
+    }
+
+  return relationship;
+};
 
 export const fetchCoachingRelationshipsWithUserNames = async (
   organizationId: Id

--- a/src/lib/api/coaching-relationships.ts
+++ b/src/lib/api/coaching-relationships.ts
@@ -6,7 +6,8 @@ import {
   defaultCoachingRelationshipWithUserNames,
   defaultCoachingRelationshipsWithUserNames,
   isCoachingRelationshipWithUserNames,
-  isCoachingRelationshipWithUserNamesArray
+  isCoachingRelationshipWithUserNamesArray,
+  parseCoachingRelationshipWithUserNames,
 } from "@/types/coaching_relationship_with_user_names";
 import { Id } from "@/types/general";
 import { AxiosError, AxiosResponse } from "axios";
@@ -17,39 +18,51 @@ export const fetchCoachingRelationshipWithUserNames = async (
 ): Promise<CoachingRelationshipWithUserNames> => {
   const axios = require("axios");
 
-  var relationship: CoachingRelationshipWithUserNames = defaultCoachingRelationshipWithUserNames();
+  var relationship: CoachingRelationshipWithUserNames =
+    defaultCoachingRelationshipWithUserNames();
   var err: string = "";
 
   const data = await axios
-    .get(`http://localhost:4000/organizations/${organization_id}/coaching_relationships/${relationship_id}`, {
-      withCredentials: true,
-      setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
-      headers: {
-        "X-Version": "0.0.1",
-      },
-    })
+    .get(
+      `http://localhost:4000/organizations/${organization_id}/coaching_relationships/${relationship_id}`,
+      {
+        withCredentials: true,
+        setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
+        headers: {
+          "X-Version": "0.0.1",
+        },
+      }
+    )
     .then(function (response: AxiosResponse) {
       // handle success
-      if (isCoachingRelationshipWithUserNames(response.data.data)) {
-        relationship = response.data.data;
+      const relationshipData = response.data.data;
+      if (isCoachingRelationshipWithUserNames(relationshipData)) {
+        relationship = parseCoachingRelationshipWithUserNames(relationshipData);
       }
     })
     .catch(function (error: AxiosError) {
       // handle error
       console.error(error.response?.status);
       if (error.response?.status == 401) {
-        err = "Retrieval of CoachingRelationshipWithUserNames failed: unauthorized.";
+        err =
+          "Retrieval of CoachingRelationshipWithUserNames failed: unauthorized.";
       } else if (error.response?.status == 500) {
-        err = "Retrieval of CoachingRelationshipWithUserNames failed, system error: " + error.response.data;
+        err =
+          "Retrieval of CoachingRelationshipWithUserNames failed, system error: " +
+          error.response.data;
       } else {
-        err = `Retrieval of CoachingRelationshipWithUserNames(` + relationship_id + `) failed: ` + error.response?.data;
+        err =
+          `Retrieval of CoachingRelationshipWithUserNames(` +
+          relationship_id +
+          `) failed: ` +
+          error.response?.data;
       }
     });
 
-    if (err) {
-      console.error(err);
-      throw err;
-    }
+  if (err) {
+    console.error(err);
+    throw err;
+  }
 
   return relationship;
 };
@@ -59,24 +72,30 @@ export const fetchCoachingRelationshipsWithUserNames = async (
 ): Promise<[CoachingRelationshipWithUserNames[], string]> => {
   const axios = require("axios");
 
-  var relationships: CoachingRelationshipWithUserNames[] = defaultCoachingRelationshipsWithUserNames();
+  var relationships: CoachingRelationshipWithUserNames[] =
+    defaultCoachingRelationshipsWithUserNames();
   var err: string = "";
 
   const data = await axios
-    .get(`http://localhost:4000/organizations/${organizationId}/coaching_relationships`, {
-      withCredentials: true,
-      setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
-      headers: {
-        "X-Version": "0.0.1",
-      },
-    })
+    .get(
+      `http://localhost:4000/organizations/${organizationId}/coaching_relationships`,
+      {
+        withCredentials: true,
+        setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
+        headers: {
+          "X-Version": "0.0.1",
+        },
+      }
+    )
     .then(function (response: AxiosResponse) {
       // handle success
       console.debug(response);
       if (isCoachingRelationshipWithUserNamesArray(response.data.data)) {
         relationships = response.data.data;
         console.debug(
-          `CoachingRelationshipsWithUserNames: ` + coachingRelationshipsWithUserNamesToString(relationships) + `.`
+          `CoachingRelationshipsWithUserNames: ` +
+            coachingRelationshipsWithUserNamesToString(relationships) +
+            `.`
         );
       }
     })
@@ -84,15 +103,22 @@ export const fetchCoachingRelationshipsWithUserNames = async (
       // handle error
       console.error(error.response?.status);
       if (error.response?.status == 401) {
-        console.error("Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.");
-        err = "Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.";
+        console.error(
+          "Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized."
+        );
+        err =
+          "Retrieval of CoachingRelationshipsWithUserNames failed: unauthorized.";
       } else {
         console.log(error);
         console.error(
-          `Retrieval of CoachingRelationshipsWithUserNames by organization Id (` + organizationId + `) failed.`
+          `Retrieval of CoachingRelationshipsWithUserNames by organization Id (` +
+            organizationId +
+            `) failed.`
         );
         err =
-          `Retrieval of CoachingRealtionshipsWithUserNames by organization Id (` + organizationId + `) failed.`;
+          `Retrieval of CoachingRealtionshipsWithUserNames by organization Id (` +
+          organizationId +
+          `) failed.`;
       }
     });
 

--- a/src/lib/api/coaching-sessions.ts
+++ b/src/lib/api/coaching-sessions.ts
@@ -4,7 +4,7 @@ import {
   CoachingSession,
   isCoachingSessionArray,
   parseCoachingSession,
-  sortCoachingSessionArray
+  sortCoachingSessionArray,
 } from "@/types/coaching-session";
 import { Id, SortOrder } from "@/types/general";
 import { AxiosError, AxiosResponse } from "axios";
@@ -21,8 +21,8 @@ export const fetchCoachingSessions = async (
   // TODO: for now we hardcode a 2 month window centered around now,
   // eventually we want to make this be configurable somewhere
   // (either on the page or elsewhere)
-  const fromDate = DateTime.now().minus({month: 1}).toISODate();
-  const toDate = DateTime.now().plus({month: 1}).toISODate();
+  const fromDate = DateTime.now().minus({ month: 1 }).toISODate();
+  const toDate = DateTime.now().plus({ month: 1 }).toISODate();
 
   console.debug("fromDate: " + fromDate);
   console.debug("toDate: " + toDate);
@@ -32,7 +32,7 @@ export const fetchCoachingSessions = async (
       params: {
         coaching_relationship_id: coachingRelationshipId,
         from_date: fromDate,
-        to_date: toDate
+        to_date: toDate,
       },
       withCredentials: true,
       setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
@@ -45,10 +45,13 @@ export const fetchCoachingSessions = async (
       var sessions_data = response.data.data;
       if (isCoachingSessionArray(sessions_data)) {
         // Sort returned sessions in ascending order by their date field
-        sessions_data = sortCoachingSessionArray(sessions_data, SortOrder.Ascending);
+        sessions_data = sortCoachingSessionArray(
+          sessions_data,
+          SortOrder.Ascending
+        );
 
         sessions_data.forEach((session_data: any) => {
-          coaching_sessions.push(parseCoachingSession(session_data))
+          coaching_sessions.push(parseCoachingSession(session_data));
         });
       }
     })
@@ -61,10 +64,14 @@ export const fetchCoachingSessions = async (
       } else {
         console.log(error);
         console.error(
-          `Retrieval of CoachingSessions by coaching relationship Id (` + coachingRelationshipId + `) failed.`
+          `Retrieval of CoachingSessions by coaching relationship Id (` +
+            coachingRelationshipId +
+            `) failed.`
         );
         err =
-          `Retrieval of CoachingSessions by coaching relationship Id (` + coachingRelationshipId + `) failed.`;
+          `Retrieval of CoachingSessions by coaching relationship Id (` +
+          coachingRelationshipId +
+          `) failed.`;
       }
     });
 

--- a/src/lib/stores/app-state-store.ts
+++ b/src/lib/stores/app-state-store.ts
@@ -1,17 +1,23 @@
+import { CoachingSession, defaultCoachingSession } from '@/types/coaching-session';
+import { CoachingRelationshipWithUserNames, defaultCoachingRelationshipWithUserNames } from '@/types/coaching_relationship_with_user_names';
 import { Id } from '@/types/general';
-import { create, useStore } from 'zustand';
+import { create } from 'zustand';
 import { createJSONStorage, devtools, persist } from 'zustand/middleware';
 
 interface AppState {
     organizationId: Id;
     relationshipId: Id;
     coachingSessionId: Id;
+    coachingSession: CoachingSession;
+    coachingRelationship: CoachingRelationshipWithUserNames;
 }
 
 interface AppStateActions {
     setOrganizationId: (organizationId: Id) => void;
     setRelationshipId: (relationshipId: Id) => void;
     setCoachingSessionId: (coachingSessionId: Id) => void;
+    setCoachingSession: (coachingSession: CoachingSession) => void;
+    setCoachingRelationship: (coachingRelationship: CoachingRelationshipWithUserNames) => void;
     reset (): void;
 }
 
@@ -21,6 +27,8 @@ export const defaultInitState: AppState = {
     organizationId: "",
     relationshipId: "",
     coachingSessionId: "",
+    coachingSession: defaultCoachingSession(),
+    coachingRelationship: defaultCoachingRelationshipWithUserNames(),
 }
 
 export const createAppStateStore = (
@@ -40,6 +48,12 @@ export const createAppStateStore = (
                     },
                     setCoachingSessionId: (coachingSessionId) => {
                         set({ coachingSessionId });
+                    },
+                    setCoachingSession: (coachingSession) => {
+                        set({ coachingSession });
+                    },
+                    setCoachingRelationship: (coachingRelationship) => {
+                        set({ coachingRelationship });
                     },
                     reset (): void {
                         set(defaultInitState);

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -1,23 +1,24 @@
 export const siteConfig = {
-    name: "Refactor Coaching & Mentoring",
-    url: "https://refactorcoach.com",
-    ogImage: "https://ui.shadcn.com/og.jpg",
-    locale: "us",
-    description:
-      "Coaching and mentorship done right.",
-    links: {
-      twitter: "https://twitter.com/shadcn",
-      github: "https://github.com/shadcn-ui/ui",
-    },
-  }
-  
-  export type SiteConfig = typeof siteConfig
+  name: "Refactor Coaching & Mentoring",
+  url: "https://refactorcoach.com",
+  ogImage: "https://ui.shadcn.com/og.jpg",
+  locale: "us",
+  titleStyle: SessionTitleStyle.CoachFirstCoacheeFirstDate,
+  description: "Coaching and mentorship done right.",
+  links: {
+    twitter: "https://twitter.com/shadcn",
+    github: "https://github.com/shadcn-ui/ui",
+  },
+};
 
-import { MainNavItem, SidebarNavItem } from "./types/nav"
+export type SiteConfig = typeof siteConfig;
+
+import { MainNavItem, SidebarNavItem } from "./types/nav";
+import { SessionTitleStyle } from "./types/session-title";
 
 interface DocsConfig {
-  mainNav: MainNavItem[]
-  sidebarNav: SidebarNavItem[]
+  mainNav: MainNavItem[];
+  sidebarNav: SidebarNavItem[];
 }
 
 export const docsConfig: DocsConfig = {
@@ -345,4 +346,4 @@ export const docsConfig: DocsConfig = {
       ],
     },
   ],
-}
+};

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -4,7 +4,7 @@ export const siteConfig = {
     ogImage: "https://ui.shadcn.com/og.jpg",
     locale: "us",
     description:
-      "A platform for software engineers and tech leaders to level up their foundational skills.",
+      "Coaching and mentorship done right.",
     links: {
       twitter: "https://twitter.com/shadcn",
       github: "https://github.com/shadcn-ui/ui",

--- a/src/types/coaching-session.ts
+++ b/src/types/coaching-session.ts
@@ -5,9 +5,9 @@ import { Id, SortOrder } from "@/types/general";
 // entity::coaching_sessions::Model
 export interface CoachingSession {
   id: Id;
-  coaching_relationship_id: Id,
-  date: DateTime,
-  timezone: String,
+  coaching_relationship_id: Id;
+  date: string;
+  timezone: string;
   created_at: DateTime;
   updated_at: DateTime;
 }
@@ -17,12 +17,12 @@ export interface CoachingSession {
 // will agree to work with internally.
 export function parseCoachingSession(data: any): CoachingSession {
   if (!isCoachingSession(data)) {
-    throw new Error('Invalid CoachingSession data');
+    throw new Error("Invalid CoachingSession data");
   }
   return {
     id: data.id,
     coaching_relationship_id: data.coaching_relationship_id,
-    date: DateTime.fromISO(data.date.toString()),
+    date: data.date,
     timezone: data.timezone,
     created_at: DateTime.fromISO(data.created_at.toString()),
     updated_at: DateTime.fromISO(data.updated_at.toString()),
@@ -30,61 +30,79 @@ export function parseCoachingSession(data: any): CoachingSession {
 }
 
 export function isCoachingSession(value: unknown): value is CoachingSession {
-    if (!value || typeof value !== "object") {
-      return false;
-    }
-    const object = value as Record<string, unknown>;
-  
-    return (
-      typeof object.id === "string" &&
-      typeof object.coaching_relationship_id === "string" &&
-      typeof object.date === "string" &&
-      typeof object.timezone === "string" &&
-      typeof object.created_at === "string" &&
-      typeof object.updated_at === "string"
-    );
+  if (!value || typeof value !== "object") {
+    return false;
   }
+  const object = value as Record<string, unknown>;
 
-export function isCoachingSessionArray(value: unknown): value is CoachingSession[] {
+  return (
+    typeof object.id === "string" &&
+    typeof object.coaching_relationship_id === "string" &&
+    typeof object.date === "string" &&
+    typeof object.timezone === "string" &&
+    typeof object.created_at === "string" &&
+    typeof object.updated_at === "string"
+  );
+}
+
+export function isCoachingSessionArray(
+  value: unknown
+): value is CoachingSession[] {
   return Array.isArray(value) && value.every(isCoachingSession);
 }
 
-export function sortCoachingSessionArray(sessions: CoachingSession[], order: SortOrder): CoachingSession[] {
+export function sortCoachingSessionArray(
+  sessions: CoachingSession[],
+  order: SortOrder
+): CoachingSession[] {
   if (order == SortOrder.Ascending) {
-    sessions.sort((a, b) => 
-      new Date(a.date.toString()).getTime() - new Date(b.date.toString()).getTime());
+    sessions.sort(
+      (a, b) =>
+        new Date(a.date.toString()).getTime() -
+        new Date(b.date.toString()).getTime()
+    );
   } else if (order == SortOrder.Descending) {
-    sessions.sort((a, b) => 
-      new Date(b.date.toString()).getTime() - new Date(a.date.toString()).getTime());
+    sessions.sort(
+      (a, b) =>
+        new Date(b.date.toString()).getTime() -
+        new Date(a.date.toString()).getTime()
+    );
   }
   return sessions;
 }
 
-export function getCoachingSessionById(id: string, sessions: CoachingSession[]): CoachingSession {
-  const session = sessions.find(session => session.id === id);
+export function getCoachingSessionById(
+  id: string,
+  sessions: CoachingSession[]
+): CoachingSession {
+  const session = sessions.find((session) => session.id === id);
   return session ? session : defaultCoachingSession();
 }
 
 export function defaultCoachingSession(): CoachingSession {
-    var now = DateTime.now();
-    return {
-      id: "",
-      coaching_relationship_id: "",
-      date: now,
-      timezone: "",
-      created_at: now,
-      updated_at: now,
-    };
-  }
-  
-  export function defaultCoachingSessions(): CoachingSession[] {
-    return [defaultCoachingSession()];
-  }
-  
-  export function coachingSessionToString(coaching_session: CoachingSession): string {
-    return JSON.stringify(coaching_session);
-  }
-  
-  export function coachingSessionsToString(coaching_sessions: CoachingSession[]): string {
-    return JSON.stringify(coaching_sessions);
-  }
+  var now = DateTime.now();
+  return {
+    id: "",
+    coaching_relationship_id: "",
+    date: "",
+    timezone: "",
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+export function defaultCoachingSessions(): CoachingSession[] {
+  return [defaultCoachingSession()];
+}
+
+export function coachingSessionToString(
+  coaching_session: CoachingSession | undefined
+): string {
+  return JSON.stringify(coaching_session);
+}
+
+export function coachingSessionsToString(
+  coaching_sessions: CoachingSession[] | undefined
+): string {
+  return JSON.stringify(coaching_sessions);
+}

--- a/src/types/coaching-session.ts
+++ b/src/types/coaching-session.ts
@@ -60,6 +60,11 @@ export function sortCoachingSessionArray(sessions: CoachingSession[], order: Sor
   return sessions;
 }
 
+export function getCoachingSessionById(id: string, sessions: CoachingSession[]): CoachingSession {
+  const session = sessions.find(session => session.id === id);
+  return session ? session : defaultCoachingSession();
+}
+
 export function defaultCoachingSession(): CoachingSession {
     var now = DateTime.now();
     return {

--- a/src/types/coaching_relationship_with_user_names.ts
+++ b/src/types/coaching_relationship_with_user_names.ts
@@ -7,35 +7,60 @@ export interface CoachingRelationshipWithUserNames {
   id: Id;
   coach_id: Id;
   coachee_id: Id;
-  coach_first_name: String;
-  coach_last_name: String;
-  coachee_first_name: String;
-  coachee_last_name: String;
+  coach_first_name: string;
+  coach_last_name: string;
+  coachee_first_name: string;
+  coachee_last_name: string;
   created_at: DateTime;
   updated_at: DateTime;
 }
 
+// The main purpose of having this parsing function is to be able to parse the
+// returned DateTimeWithTimeZone (Rust type) string into something that ts-luxon
+// will agree to work with internally.
+export function parseCoachingRelationshipWithUserNames(data: any): CoachingRelationshipWithUserNames {
+  if (!isCoachingRelationshipWithUserNames(data)) {
+    throw new Error('Invalid CoachingRelationshipWithUserNames object data');
+  }
+  return {
+    id: data.id,
+    coach_id: data.coach_id,
+    coachee_id: data.coachee_id,
+    coach_first_name: data.coach_first_name,
+    coach_last_name: data.coach_last_name,
+    coachee_first_name: data.coachee_first_name,
+    coachee_last_name: data.coachee_last_name,
+    created_at: DateTime.fromISO(data.created_at.toString()),
+    updated_at: DateTime.fromISO(data.updated_at.toString()),
+  };
+}
+
 export function isCoachingRelationshipWithUserNames(value: unknown): value is CoachingRelationshipWithUserNames {
     if (!value || typeof value !== "object") {
-      return false;
-    }
-    const object = value as Record<string, unknown>;
-  
-    return (
-      typeof object.id === "string" &&
-      typeof object.coach_id === "string" &&
-      typeof object.coachee_id === "string" &&
-      typeof object.coach_first_name === "string" &&
-      typeof object.coach_last_name === "string" &&
-      typeof object.coachee_first_name === "string" &&
-      typeof object.coachee_last_name === "string" &&
-      typeof object.created_at === "string" &&
-      typeof object.updated_at === "string"
-    );
+    return false;
   }
+  const object = value as Record<string, unknown>;
+
+  return (
+    typeof object.id === "string" &&
+    typeof object.coach_id === "string" &&
+    typeof object.coachee_id === "string" &&
+    typeof object.coach_first_name === "string" &&
+    typeof object.coach_last_name === "string" &&
+    typeof object.coachee_first_name === "string" &&
+    typeof object.coachee_last_name === "string" &&
+    typeof object.created_at === "string" &&
+    typeof object.updated_at === "string"
+  );
+}
 
 export function isCoachingRelationshipWithUserNamesArray(value: unknown): value is CoachingRelationshipWithUserNames[] {
   return Array.isArray(value) && value.every(isCoachingRelationshipWithUserNames);
+}
+
+export function getCoachingRelationshipById(id: string, relationships: CoachingRelationshipWithUserNames[]): CoachingRelationshipWithUserNames {
+  const relationship = relationships.find(relationship => relationship.id === id);
+  return relationship ? relationship : defaultCoachingRelationshipWithUserNames();
 }
 
 export function defaultCoachingRelationshipWithUserNames(): CoachingRelationshipWithUserNames {

--- a/src/types/coaching_relationship_with_user_names.ts
+++ b/src/types/coaching_relationship_with_user_names.ts
@@ -18,9 +18,11 @@ export interface CoachingRelationshipWithUserNames {
 // The main purpose of having this parsing function is to be able to parse the
 // returned DateTimeWithTimeZone (Rust type) string into something that ts-luxon
 // will agree to work with internally.
-export function parseCoachingRelationshipWithUserNames(data: any): CoachingRelationshipWithUserNames {
+export function parseCoachingRelationshipWithUserNames(
+  data: any
+): CoachingRelationshipWithUserNames {
   if (!isCoachingRelationshipWithUserNames(data)) {
-    throw new Error('Invalid CoachingRelationshipWithUserNames object data');
+    throw new Error("Invalid CoachingRelationshipWithUserNames object data");
   }
   return {
     id: data.id,
@@ -35,8 +37,10 @@ export function parseCoachingRelationshipWithUserNames(data: any): CoachingRelat
   };
 }
 
-export function isCoachingRelationshipWithUserNames(value: unknown): value is CoachingRelationshipWithUserNames {
-    if (!value || typeof value !== "object") {
+export function isCoachingRelationshipWithUserNames(
+  value: unknown
+): value is CoachingRelationshipWithUserNames {
+  if (!value || typeof value !== "object") {
     return false;
   }
   const object = value as Record<string, unknown>;
@@ -54,38 +58,53 @@ export function isCoachingRelationshipWithUserNames(value: unknown): value is Co
   );
 }
 
-export function isCoachingRelationshipWithUserNamesArray(value: unknown): value is CoachingRelationshipWithUserNames[] {
-  return Array.isArray(value) && value.every(isCoachingRelationshipWithUserNames);
+export function isCoachingRelationshipWithUserNamesArray(
+  value: unknown
+): value is CoachingRelationshipWithUserNames[] {
+  return (
+    Array.isArray(value) && value.every(isCoachingRelationshipWithUserNames)
+  );
 }
 
-export function getCoachingRelationshipById(id: string, relationships: CoachingRelationshipWithUserNames[]): CoachingRelationshipWithUserNames {
-  const relationship = relationships.find(relationship => relationship.id === id);
-  return relationship ? relationship : defaultCoachingRelationshipWithUserNames();
+export function getCoachingRelationshipById(
+  id: string,
+  relationships: CoachingRelationshipWithUserNames[]
+): CoachingRelationshipWithUserNames {
+  const relationship = relationships.find(
+    (relationship) => relationship.id === id
+  );
+  return relationship
+    ? relationship
+    : defaultCoachingRelationshipWithUserNames();
 }
 
 export function defaultCoachingRelationshipWithUserNames(): CoachingRelationshipWithUserNames {
-    var now = DateTime.now();
-    return {
-      id: "",
-      coach_id: "",
-      coachee_id: "",
-      coach_first_name: "",
-      coach_last_name: "",
-      coachee_first_name: "",
-      coachee_last_name: "",
-      created_at: now,
-      updated_at: now,
-    };
-  }
-  
-  export function defaultCoachingRelationshipsWithUserNames(): CoachingRelationshipWithUserNames[] {
-    return [defaultCoachingRelationshipWithUserNames()];
-  }
-  
-  export function coachingRelationshipWithUserNamesToString(relationship: CoachingRelationshipWithUserNames): string {
-    return JSON.stringify(relationship);
-  }
-  
-  export function coachingRelationshipsWithUserNamesToString(relationships: CoachingRelationshipWithUserNames[]): string {
-    return JSON.stringify(relationships);
-  }
+  var now = DateTime.now();
+  return {
+    id: "",
+    coach_id: "",
+    coachee_id: "",
+    coach_first_name: "",
+    coach_last_name: "",
+    coachee_first_name: "",
+    coachee_last_name: "",
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+export function defaultCoachingRelationshipsWithUserNames(): CoachingRelationshipWithUserNames[] {
+  return [defaultCoachingRelationshipWithUserNames()];
+}
+
+export function coachingRelationshipWithUserNamesToString(
+  relationship: CoachingRelationshipWithUserNames | undefined
+): string {
+  return JSON.stringify(relationship);
+}
+
+export function coachingRelationshipsWithUserNamesToString(
+  relationships: CoachingRelationshipWithUserNames[] | undefined
+): string {
+  return JSON.stringify(relationships);
+}

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -1,21 +1,23 @@
+import { DateTime } from "ts-luxon";
+
 // A type alias for each entity's Id field
 export type Id = string;
 
 // A sorting type that can be used by any of our custom types when stored
 // as arrays
 export enum SortOrder {
-    Ascending = "ascending",
-    Descending = "descending"
-  }
+  Ascending = "ascending",
+  Descending = "descending",
+}
 
 export enum ActionStatus {
   NotStarted = "NotStarted",
   InProgress = "InProgress",
   Completed = "Completed",
-  WontDo = "WontDo"
+  WontDo = "WontDo",
 }
 
-export function stringToActionStatus(statusString: string): (ActionStatus) {
+export function stringToActionStatus(statusString: string): ActionStatus {
   const status = statusString.trim();
 
   if (status == "InProgress") {
@@ -29,7 +31,7 @@ export function stringToActionStatus(statusString: string): (ActionStatus) {
   }
 }
 
-export function actionStatusToString(actionStatus: ActionStatus): (string) {
+export function actionStatusToString(actionStatus: ActionStatus): string {
   if (actionStatus == "InProgress") {
     return "In Progress";
   } else if (actionStatus == "Completed") {
@@ -39,4 +41,18 @@ export function actionStatusToString(actionStatus: ActionStatus): (string) {
   } else {
     return "Not Started";
   }
+}
+
+/// Given a valid ISO formatted date time string (timestampz in Postgresql types),
+/// return a valid DateTime object instance.
+export function getDateTimeFromString(dateTime: string): DateTime {
+  const dt = dateTime.trim();
+  if (dt.length == 0) {
+    console.warn(
+      "Return DateTime.now() since input dateTime string was empty."
+    );
+    return DateTime.now();
+  }
+
+  return DateTime.fromISO(dt);
 }

--- a/src/types/session-title.ts
+++ b/src/types/session-title.ts
@@ -1,0 +1,130 @@
+import { DateTime } from "ts-luxon";
+import { CoachingRelationshipWithUserNames } from "./coaching_relationship_with_user_names";
+import { CoachingSession } from "./coaching-session";
+
+// This is a frontend type only, it does not reflect any literal entity model
+// from the backend.
+export interface SessionTitle {
+  title: string;
+  style: SessionTitleStyle;
+}
+
+// Different title rendering styles
+export enum SessionTitleStyle {
+  CoachFirstCoacheeFirst,
+  CoachFirstLastCoacheeFirstLast,
+  CoachFirstCoacheeFirstDate,
+  CoachFirstCoacheeFirstDateTime,
+}
+
+function constructCoachFirstCoacheeFirstTitle(
+  coach_first_name: string,
+  coachee_first_name: string
+): string {
+  return coach_first_name + " <> " + coachee_first_name;
+}
+
+function constructCoachFirstLastCoacheeFirstLastTitle(
+  coach_first_name: string,
+  coach_last_name: string,
+  coachee_first_name: string,
+  coachee_last_name: string
+): string {
+  return (
+    coach_first_name +
+    " " +
+    coach_last_name +
+    " <> " +
+    coachee_first_name +
+    " " +
+    coachee_last_name
+  );
+}
+
+function constructCoachFirstCoacheeFirstDate(
+  coach_first_name: string,
+  coachee_first_name: string,
+  date: DateTime,
+  locale: string
+): string {
+  const formattedDateTime = date
+    .setLocale(locale)
+    .toLocaleString(DateTime.DATE_MED);
+  return (
+    coach_first_name + " <> " + coachee_first_name + " @ " + formattedDateTime
+  );
+}
+
+function constructCoachFirstCoacheeFirstDateTime(
+  coach_first_name: string,
+  coachee_first_name: string,
+  date: DateTime,
+  locale: string
+): string {
+  const formattedDateTime = date
+    .setLocale(locale)
+    .toLocaleString(DateTime.DATETIME_MED);
+  return (
+    coach_first_name + " <> " + coachee_first_name + " @ " + formattedDateTime
+  );
+}
+
+export function generateSessionTitle(
+  session: CoachingSession,
+  relationship: CoachingRelationshipWithUserNames,
+  style: SessionTitleStyle,
+  locale: string
+): SessionTitle {
+  var sessionTitleStr = "";
+
+  console.debug(
+    "relationship.coach_first_name: " + relationship.coach_first_name
+  );
+  console.debug(
+    "relationship.coachee_first_name: " + relationship.coachee_first_name
+  );
+  console.debug("session.date: " + session.date);
+  if (style == SessionTitleStyle.CoachFirstCoacheeFirst) {
+    sessionTitleStr = constructCoachFirstCoacheeFirstTitle(
+      relationship.coach_first_name,
+      relationship.coachee_first_name
+    );
+  } else if (style == SessionTitleStyle.CoachFirstLastCoacheeFirstLast) {
+    sessionTitleStr = constructCoachFirstLastCoacheeFirstLastTitle(
+      relationship.coach_first_name,
+      relationship.coach_last_name,
+      relationship.coachee_first_name,
+      relationship.coachee_last_name
+    );
+  } else if (style == SessionTitleStyle.CoachFirstCoacheeFirstDate) {
+    sessionTitleStr = constructCoachFirstCoacheeFirstDate(
+      relationship.coach_first_name,
+      relationship.coachee_first_name,
+      session.date,
+      locale
+    );
+  } else if (style == SessionTitleStyle.CoachFirstCoacheeFirstDateTime) {
+    sessionTitleStr = constructCoachFirstCoacheeFirstDateTime(
+      relationship.coach_first_name,
+      relationship.coachee_first_name,
+      session.date,
+      locale
+    );
+  }
+
+  return {
+    title: sessionTitleStr,
+    style: style,
+  };
+}
+
+export function defaultSessionTitle(): SessionTitle {
+  return {
+    title: "",
+    style: SessionTitleStyle.CoachFirstCoacheeFirst,
+  };
+}
+
+export function sessionTitleToString(sessionTitle: SessionTitle): string {
+  return JSON.stringify(sessionTitle);
+}

--- a/src/types/session-title.ts
+++ b/src/types/session-title.ts
@@ -1,6 +1,8 @@
 import { DateTime } from "ts-luxon";
 import { CoachingRelationshipWithUserNames } from "./coaching_relationship_with_user_names";
 import { CoachingSession } from "./coaching-session";
+import { siteConfig } from "@/site.config";
+import { getDateTimeFromString } from "./general";
 
 // This is a frontend type only, it does not reflect any literal entity model
 // from the backend.
@@ -44,29 +46,33 @@ function constructCoachFirstLastCoacheeFirstLastTitle(
 function constructCoachFirstCoacheeFirstDate(
   coach_first_name: string,
   coachee_first_name: string,
-  date: DateTime,
+  date: string,
   locale: string
 ): string {
-  const formattedDateTime = date
-    .setLocale(locale)
-    .toLocaleString(DateTime.DATE_MED);
-  return (
-    coach_first_name + " <> " + coachee_first_name + " @ " + formattedDateTime
-  );
+  var title = coach_first_name + " <> " + coachee_first_name;
+  var formattedDateTime =
+    " @ " +
+    getDateTimeFromString(date)
+      .setLocale(locale)
+      .toLocaleString(DateTime.DATE_MED);
+
+  return coach_first_name + " <> " + coachee_first_name + formattedDateTime;
 }
 
 function constructCoachFirstCoacheeFirstDateTime(
   coach_first_name: string,
   coachee_first_name: string,
-  date: DateTime,
+  date: string,
   locale: string
 ): string {
-  const formattedDateTime = date
-    .setLocale(locale)
-    .toLocaleString(DateTime.DATETIME_MED);
-  return (
-    coach_first_name + " <> " + coachee_first_name + " @ " + formattedDateTime
-  );
+  var title = coach_first_name + " <> " + coachee_first_name;
+  var formattedDateTime =
+    " @ " +
+    getDateTimeFromString(date)
+      .setLocale(locale)
+      .toLocaleString(DateTime.DATETIME_MED);
+
+  return coach_first_name + " <> " + coachee_first_name + formattedDateTime;
 }
 
 export function generateSessionTitle(
@@ -77,13 +83,6 @@ export function generateSessionTitle(
 ): SessionTitle {
   var sessionTitleStr = "";
 
-  console.debug(
-    "relationship.coach_first_name: " + relationship.coach_first_name
-  );
-  console.debug(
-    "relationship.coachee_first_name: " + relationship.coachee_first_name
-  );
-  console.debug("session.date: " + session.date);
   if (style == SessionTitleStyle.CoachFirstCoacheeFirst) {
     sessionTitleStr = constructCoachFirstCoacheeFirstTitle(
       relationship.coach_first_name,
@@ -120,8 +119,8 @@ export function generateSessionTitle(
 
 export function defaultSessionTitle(): SessionTitle {
   return {
-    title: "",
-    style: SessionTitleStyle.CoachFirstCoacheeFirst,
+    title: "Untitled Session",
+    style: siteConfig.titleStyle,
   };
 }
 


### PR DESCRIPTION
## Description
This PR constructs a title for a coaching session in 4 different styles (first names only, first and last names, first names + date, first names + date and time).


#### GitHub Issue: None

### Changes
* Add a new CoachingSessionTitle component to render a dynamic coaching session title
* Add a new SessionTitle object type
* Store CoachingSession and CoachingRelationship instances in AppStateStore instead of only coachingSessionId and relationshipId.

### Screenshots / Videos Showing UI Changes (if applicable)
![Jim __ Caleb _ Oct 3_ 2024](https://github.com/user-attachments/assets/d8003efd-7b9d-4b37-b895-a018615e7ff4)

### Testing Strategy
Navigate to a coaching session and observe that a title is shown (should be in the style of first names + date by default)


### Concerns
None