### PR TITLE
Store full organization in AppStateStore and use it

### DIFF
--- a/src/components/ui/dashboard/select-coaching-session.tsx
+++ b/src/components/ui/dashboard/select-coaching-session.tsx
@@ -34,7 +34,11 @@ import {
   getCoachingRelationshipById,
 } from "@/types/coaching_relationship_with_user_names";
 import { getDateTimeFromString, Id } from "@/types/general";
-import { Organization } from "@/types/organization";
+import {
+  getOrganizationById,
+  Organization,
+  organizationToString,
+} from "@/types/organization";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { DateTime } from "ts-luxon";
@@ -51,6 +55,7 @@ export function SelectCoachingSession({
   const { organizationId, setOrganizationId } = useAppStateStore(
     (state) => state
   );
+  const { organization, setOrganization } = useAppStateStore((state) => state);
   const { relationshipId, setRelationshipId } = useAppStateStore(
     (state) => state
   );
@@ -129,6 +134,13 @@ export function SelectCoachingSession({
     loadCoachingSessions();
   }, [relationshipId]);
 
+  const handleSetOrganization = (organizationId: Id) => {
+    setOrganizationId(organizationId);
+    const organization = getOrganizationById(organizationId, organizations);
+    console.debug("organization: " + organizationToString(organization));
+    setOrganization(organization);
+  };
+
   const handleSetCoachingRelationship = (coachingRelationshipId: string) => {
     setRelationshipId(coachingRelationshipId);
     const coachingRelationship = getCoachingRelationshipById(
@@ -168,7 +180,7 @@ export function SelectCoachingSession({
           <Select
             defaultValue="0"
             value={organizationId}
-            onValueChange={setOrganizationId}
+            onValueChange={handleSetOrganization}
           >
             <SelectTrigger id="organization">
               <SelectValue placeholder="Select organization" />

--- a/src/components/ui/main-nav-menu.tsx
+++ b/src/components/ui/main-nav-menu.tsx
@@ -49,9 +49,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { useAppStateStore } from "@/lib/providers/app-state-store-provider";
 
 export function MainNavMenu() {
   const [open, setIsOpen] = React.useState(false);
+  const { organization } = useAppStateStore((state) => state);
 
   return (
     <>
@@ -60,8 +62,8 @@ export function MainNavMenu() {
           <NavigationMenuItem>
             <NavigationMenuTrigger>
               <span className="hidden font-bold sm:inline-block">
-                {/* TODO: Replace this with currently selected organization's name */}
-                Refactor Coaching
+                {/* FIXME: Replace "Refactor" with something from siteConfig or something else */}
+                {organization.name.length > 0 ? organization.name : "Refactor"}
               </span>
             </NavigationMenuTrigger>
             <NavigationMenuContent>

--- a/src/lib/stores/app-state-store.ts
+++ b/src/lib/stores/app-state-store.ts
@@ -1,70 +1,83 @@
-import { CoachingSession, defaultCoachingSession } from '@/types/coaching-session';
-import { CoachingRelationshipWithUserNames, defaultCoachingRelationshipWithUserNames } from '@/types/coaching_relationship_with_user_names';
-import { Id } from '@/types/general';
-import { create } from 'zustand';
-import { createJSONStorage, devtools, persist } from 'zustand/middleware';
+import {
+  CoachingSession,
+  defaultCoachingSession,
+} from "@/types/coaching-session";
+import {
+  CoachingRelationshipWithUserNames,
+  defaultCoachingRelationshipWithUserNames,
+} from "@/types/coaching_relationship_with_user_names";
+import { Id } from "@/types/general";
+import { defaultOrganization, Organization } from "@/types/organization";
+import { create } from "zustand";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
 
 interface AppState {
-    organizationId: Id;
-    relationshipId: Id;
-    coachingSessionId: Id;
-    coachingSession: CoachingSession;
-    coachingRelationship: CoachingRelationshipWithUserNames;
+  organizationId: Id;
+  relationshipId: Id;
+  coachingSessionId: Id;
+  organization: Organization;
+  coachingSession: CoachingSession;
+  coachingRelationship: CoachingRelationshipWithUserNames;
 }
 
 interface AppStateActions {
-    setOrganizationId: (organizationId: Id) => void;
-    setRelationshipId: (relationshipId: Id) => void;
-    setCoachingSessionId: (coachingSessionId: Id) => void;
-    setCoachingSession: (coachingSession: CoachingSession) => void;
-    setCoachingRelationship: (coachingRelationship: CoachingRelationshipWithUserNames) => void;
-    reset (): void;
+  setOrganizationId: (organizationId: Id) => void;
+  setRelationshipId: (relationshipId: Id) => void;
+  setCoachingSessionId: (coachingSessionId: Id) => void;
+  setOrganization: (organization: Organization) => void;
+  setCoachingSession: (coachingSession: CoachingSession) => void;
+  setCoachingRelationship: (
+    coachingRelationship: CoachingRelationshipWithUserNames
+  ) => void;
+  reset(): void;
 }
 
 export type AppStateStore = AppState & AppStateActions;
 
 export const defaultInitState: AppState = {
-    organizationId: "",
-    relationshipId: "",
-    coachingSessionId: "",
-    coachingSession: defaultCoachingSession(),
-    coachingRelationship: defaultCoachingRelationshipWithUserNames(),
-}
+  organizationId: "",
+  relationshipId: "",
+  coachingSessionId: "",
+  organization: defaultOrganization(),
+  coachingSession: defaultCoachingSession(),
+  coachingRelationship: defaultCoachingRelationshipWithUserNames(),
+};
 
-export const createAppStateStore = (
-    initState: AppState = defaultInitState,
-) => {
-    const appStateStore = create<AppStateStore>()(
-        devtools(
-            persist(
-                (set) => ({
-                    ... initState,
+export const createAppStateStore = (initState: AppState = defaultInitState) => {
+  const appStateStore = create<AppStateStore>()(
+    devtools(
+      persist(
+        (set) => ({
+          ...initState,
 
-                    setOrganizationId: (organizationId) => {
-                        set({ organizationId });
-                    },
-                    setRelationshipId: (relationshipId) => {
-                        set({ relationshipId });
-                    },
-                    setCoachingSessionId: (coachingSessionId) => {
-                        set({ coachingSessionId });
-                    },
-                    setCoachingSession: (coachingSession) => {
-                        set({ coachingSession });
-                    },
-                    setCoachingRelationship: (coachingRelationship) => {
-                        set({ coachingRelationship });
-                    },
-                    reset (): void {
-                        set(defaultInitState);
-                    }
-                }),
-                {
-                    name: 'app-state-store',
-                    storage: createJSONStorage(() => sessionStorage),
-                }
-            )
-        )
+          setOrganizationId: (organizationId) => {
+            set({ organizationId });
+          },
+          setRelationshipId: (relationshipId) => {
+            set({ relationshipId });
+          },
+          setCoachingSessionId: (coachingSessionId) => {
+            set({ coachingSessionId });
+          },
+          setOrganization: (organization) => {
+            set({ organization });
+          },
+          setCoachingSession: (coachingSession) => {
+            set({ coachingSession });
+          },
+          setCoachingRelationship: (coachingRelationship) => {
+            set({ coachingRelationship });
+          },
+          reset(): void {
+            set(defaultInitState);
+          },
+        }),
+        {
+          name: "app-state-store",
+          storage: createJSONStorage(() => sessionStorage),
+        }
+      )
     )
-    return appStateStore;
-}
+  );
+  return appStateStore;
+};

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -30,6 +30,16 @@ export function isOrganizationsArray(value: unknown): value is Organization[] {
   return Array.isArray(value) && value.every(isOrganization);
 }
 
+export function getOrganizationById(
+  id: string,
+  organizations: Organization[]
+): Organization {
+  const organization = organizations.find(
+    (organization) => organization.id === id
+  );
+  return organization ? organization : defaultOrganization();
+}
+
 export function defaultOrganization(): Organization {
   var now = DateTime.now();
   return {


### PR DESCRIPTION
## Description
This PR uses the selected organization.name from the dashboard to set the organization name displayed on the main-nav-menu component.

Note: merge PR #35 before this one

#### GitHub Issue: None

### Changes
* Add a full Organization instance to AppStateStore
* Set the main-nav-menu's organization name by organization.name from AppStateStore.

### Screenshots / Videos Showing UI Changes (if applicable)
![Jim __ Caleb _ Oct 3_ 2024](https://github.com/user-attachments/assets/540d432a-972a-47f3-bc1c-b41d227e64d6)

### Testing Strategy
1. Select and navigate to a coaching session
2. Notice that the main-menu-nav organization menu's title reflects the selected organization's name that was selected from the dashboard page

### Concerns
None